### PR TITLE
Fixing multi diagnosis detection

### DIFF
--- a/lib/api/omim.py
+++ b/lib/api/omim.py
@@ -295,6 +295,8 @@ class Omim:
     def omim_id_to_phenotypic_series(self, omim_id: str) -> str:
         '''Translate omim id to phenotypic series id, or if it does
         not exist to the empty string.'''
+        assert isinstance(omim_id, str), "OMIM ID has to be string."
+
         ps_label = ""
         # take the first phenotypic series entry or if empty leave the
         # empty string

--- a/lib/model/case.py
+++ b/lib/model/case.py
@@ -271,14 +271,17 @@ class Case:
         # check whether multiple diagnoses are in same phenotypic series
         if omim:
             diagnosis_series = [
-                omim.omim_id_to_phenotypic_series(d)
+                omim.omim_id_to_phenotypic_series(str(d)) or str(d)
                 for d in diagnosis["omim_id"]
             ]
             if len(set(diagnosis_series)) > 1:
                 issues.append(
                     {
                         "type": "MULTI_DIAGNOSIS",
-                        "data": list(diagnosis["omim_id"])
+                        "data": {
+                            "orig": list(diagnosis["omim_id"]),
+                            "series": diagnosis_series
+                        }
                     }
                 )
                 valid = False

--- a/lib/model/json.py
+++ b/lib/model/json.py
@@ -451,11 +451,20 @@ class NewJson(JsonFile):
         # preprare the confirmed diagnosis for joining with the main syndrome
         # dataframe
         if self._js['selected_syndromes']:
-            selected = pandas.DataFrame.from_dict(
-                self._js['selected_syndromes'])
+            selected_syndromes = [
+                dict(
+                    s,
+                    omim_id=[s["omim_id"]]
+                    if not isinstance(s["omim_id"], list)
+                    else s["omim_id"]
+                    or ["0"]
+                )
+                for s in self._js["selected_syndromes"]
+            ]
+            selected = pandas.DataFrame.from_dict(selected_syndromes)
 
-            selected['omim_id'] = selected['omim_id'].apply(
-                lambda x: not isinstance(x, list) and [x] or x)
+            # create multiple rows from list of omim_id entries duplicating
+            # other information
             selected = explode_df_column(selected, 'omim_id')
             # add a confirmed diagnosis column
             selected['confirmed'] = True


### PR DESCRIPTION
Multi Diagnosis Phenotypic Series reduction did not work, because of some format issues in phenotypic series conversion.

Added a check in conversion to prevent future issues. (Especially with floats, since direct string conversion will not work well)