### PR TITLE
Adding VCF checks to QC

### DIFF
--- a/lib/model/case.py
+++ b/lib/model/case.py
@@ -304,6 +304,23 @@ class Case:
 
         return valid, issues
 
+    def check_vcf(self):
+        issues = []
+        valid = True
+        # check simulated vcf is correct
+        if hasattr(self, "vcf"):
+            if isinstance(self.vcf, str):
+                issues.append(
+                    {
+                        "type": "VCF_ERROR",
+                        "data": self.vcf
+                    }
+                )
+                valid = False
+        else:
+            valid = False
+        return valid, issues
+
     def get_variants(
             self,
             exclusion: Union[bool, None] = None


### PR DESCRIPTION
Adding VCF checks to QC.

Also refactored the preprocess.py script. This is necessary to reorder the QC generation after VCF generation, but also enabling the possibility to skip VCF generation (which is expensive) for testing.

VCF files are now only generated for files passing all qc checks. So this should also solve #35.