### PR TITLE
geneList merged on syndrome omim id

### DIFF
--- a/lib/api/omim.py
+++ b/lib/api/omim.py
@@ -94,6 +94,13 @@ class Omim:
             "type": "json",
             "colnames": []
         },
+        "mimTitles": {
+            "filename": "mimTitles.txt",
+            "type": "pandas",
+            "colnames": [
+                "prefix", "mim_number", "title", "alt", "inc"
+            ]
+        }
     }
 
     indexes_meta = {
@@ -202,6 +209,9 @@ class Omim:
             data['phen_mim_number'] = data['phenotype'].apply(
                 self.extract_omim
             )
+        if filename == "mimTitles":
+            data["mim_number"] = data["mim_number"].astype(int)
+            data.set_index("mim_number", inplace=True)
         return data
 
     @staticmethod
@@ -267,7 +277,10 @@ class Omim:
         '''
         if not os.path.exists(filename):
             raise RuntimeError(
-                "{} does not exist. Add them to the location manually.")
+                "{} does not exist. Add them to the location manually.".format(
+                    filename
+                )
+            )
         return pandas.read_table(
             filename, delimiter='\t', comment='#', names=colnames, dtype=str)
 
@@ -324,6 +337,14 @@ class Omim:
                 self.indexes["pheno_omim"][str(mim_pheno)]
             ]
         return []
+
+    def mim_pheno_to_syndrome_name(self, mim_pheno):
+        '''Phenotypic omim id to syndrome name.'''
+        return self.search_table(
+            self.files["mimTitles"],
+            int(mim_pheno),
+            "title"
+        )
 
     def mim_pheno_to_gene(self, mim_pheno):
         '''Convert a phenotype omim id to a gene dictionary object containing

--- a/lib/model/case.py
+++ b/lib/model/case.py
@@ -121,7 +121,11 @@ class Case:
                 str(disease_id)
             ) or str(disease_id)
 
-            syndrome_name = omim.mim_pheno_to_syndrome_name(disease_id)
+            syndrome_name = (
+                syndrome["syndrome_name"]
+                or syndrome["disease-name_pheno"]
+                or syndrome["disease-name_boqa"]
+            )
 
             genes = list(omim.mim_pheno_to_gene(disease_id).values())
             if syndrome["gene-id"]:
@@ -141,7 +145,7 @@ class Case:
 
                 # uniqueness constraint on disease_id and
                 # gene_id
-                key = "{}|{}".format(disease_id, gene["gene_id"])
+                key = "{}|{}".format(syndrome_name, gene["gene_id"])
                 update_data = dict(
                     {
                         "disease_id": disease_id,

--- a/lib/model/case.py
+++ b/lib/model/case.py
@@ -121,11 +121,7 @@ class Case:
                 str(disease_id)
             ) or str(disease_id)
 
-            syndrome_name = (
-                syndrome["syndrome_name"]
-                or syndrome["disease-name_pheno"]
-                or syndrome["disease-name_boqa"]
-            )
+            syndrome_name = omim.mim_pheno_to_syndrome_name(disease_id)
 
             genes = list(omim.mim_pheno_to_gene(disease_id).values())
             if syndrome["gene-id"]:
@@ -143,9 +139,9 @@ class Case:
                 if not gene["gene_id"]:
                     continue
 
-                # uniqueness constraint on phenotypic series and
+                # uniqueness constraint on disease_id and
                 # gene_id
-                key = "{}|{}".format(phenotypic_series, gene["gene_id"])
+                key = "{}|{}".format(disease_id, gene["gene_id"])
                 update_data = dict(
                     {
                         "disease_id": disease_id,

--- a/preprocess.py
+++ b/preprocess.py
@@ -160,6 +160,19 @@ def create_jsons(args, config_data):
 
     print('Unfiltered', len(new_json_objs))
 
+    if config_data.jsonparser["json_qc_log"] and not args.single:
+        qc_failed_results = [
+            {
+                "case_id": case_id,
+                "issues": issues,
+                "valid": valid
+            }
+            for case_id, (valid, issues) in
+            [(j.get_case_id(), j.check()) for j in new_json_objs]
+        ]
+        with open(config_data.jsonparser["json_qc_log"], "w") as failedfile:
+            json.dump(qc_failed_results, failedfile, indent=4)
+
     filtered_new = [j for j in new_json_objs if j.check()[0]]
     print('Filtered rough criteria', len(filtered_new))
     return filtered_new

--- a/tests/test_omim.py
+++ b/tests/test_omim.py
@@ -83,3 +83,13 @@ class OmimTest(BaseConfig):
             with self.subTest(i=test):
                 replaced = self.omim.replace_deprecated_all(test)
                 self.assertListEqual(replaced, correct)
+
+    def test_pheno_to_name(self):
+        tests = [
+            ("135900", "COFFIN-SIRIS SYNDROME 1; CSS1"),
+            ("106200", "MOVED TO 106210"),
+        ]
+        for test, correct in tests:
+            with self.subTest(i=test):
+                res = self.omim.mim_pheno_to_syndrome_name(test)
+                self.assertEqual(res, correct)


### PR DESCRIPTION
Genes converted from syndromes based on omim id list from face2gene will
be merged if the disease id (phenotypic omim id) is the same.

Syndrome names in the geneList will be obtained from mimTitles instead
of inferred from other information. Mismatches in Name and OMIM ID
should be less confusing to a viewer.