### PR TITLE
Adding last_modified check in aws download

### DIFF
--- a/lib/download.py
+++ b/lib/download.py
@@ -14,6 +14,8 @@ function.
 import os
 import logging
 
+import time
+import datetime
 import boto3
 
 from lib.constants import AWS_BUCKET_NAME
@@ -21,6 +23,22 @@ from lib import visual
 
 
 LOGGER = logging.getLogger(__name__)
+
+
+def load_timestamp(path: str) -> datetime.datetime:
+    '''Get timestamp from file.'''
+    if os.path.exists(path):
+        with open(path, "r") as tfile:
+            timestamp = float(tfile.read())
+    else:
+        timestamp = 0.0
+    return datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc)
+
+
+def save_current_time(path: str) -> None:
+    '''Save current time as UNIX timestamp to the specified file.'''
+    with open(path, "w") as tfile:
+        tfile.write(str(time.time()))
 
 
 def backup_s3_folder(
@@ -39,13 +57,16 @@ def backup_s3_folder(
                                  aws_access_key_id=aws_access_key,
                                  aws_secret_access_key=aws_secret_key)
 
-    if not os.path.exists(download_location):
-        logging.info("Making download directory")
-        os.makedirs(download_location)
+    os.makedirs(download_location, exist_ok=True)
 
     bucket = s3_resource.Bucket(AWS_BUCKET_NAME)
 
+    # time information
+    time_path = os.path.join(download_location, ".LAST_UPDATE")
+    last_update = load_timestamp(time_path)
+
     downloaded = 0
+    updated = 0
     # iterate over all items and check whether they already exist on the drive
     # take note, that this does not check for the integrity, so corrupted
     # files will need to be removed manually
@@ -62,20 +83,28 @@ def backup_s3_folder(
         filename = filename.strip('/')
         path = path.strip('/')
         dlpath = os.path.join(download_location, path, filename)
-        all_files = i
-        if os.path.exists(dlpath):
+        edit_time = key.last_modified
+        if os.path.exists(dlpath) and edit_time <= last_update:
             LOGGER.debug("File %s already exists. Skipping...", dlpath)
             continue
+        elif edit_time > last_update:
+            LOGGER.debug(
+                "File %s change time %s will be updated.",
+                dlpath, str(edit_time)
+            )
+            updated += 1
+        else:
+            downloaded += 1
         # download file to specified location this process might be unreliable
         # some exceptions might need to be caught for the process to run
         # reliably
-        if not os.path.exists(os.path.join(download_location, path)):
-            os.makedirs(os.path.join(download_location, path))
+        os.makedirs(os.path.join(download_location, path), exist_ok=True)
         LOGGER.debug("Downloading %s", filename)
         bucket.download_file(key.key, dlpath)
-        downloaded += 1
     # stop progressbar
     print("")
 
-    LOGGER.info("S3 Stats: Downloaded %d new of %d total files.",
-                downloaded, all_files)
+    save_current_time(time_path)
+
+    LOGGER.info("S3 Stats: Downloaded %d new %d updated of %d total files.",
+                downloaded, updated, num_objs)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -2,21 +2,17 @@ import os
 import shutil
 import unittest
 from lib import download
-from lib.model import config
 
-INPUT_PATH = os.path.join(
-    os.path.dirname(os.path.realpath(__file__)),
-    "data")
+from tests.test_config import BaseConfig
 
+class DownloadTest(BaseConfig):
 
-class DownloadTest(unittest.TestCase):
-
-    def setUp(self):
-        self.config = config.ConfigManager(
-            os.path.join(INPUT_PATH, "config.ini"))
-
-        self.dl_clean = os.path.join(INPUT_PATH, "test_clean")
-        os.makedirs(self.dl_clean)
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        base, data = os.path.split(cls.input_path)
+        cls.dl_clean = os.path.join(base, "aws")
+        os.makedirs(cls.dl_clean, exist_ok=True)
 
     def test_download_clean(self):
         download.backup_s3_folder(


### PR DESCRIPTION
Add a last update timestamp to track newly changed files in the AWS bucket.

An initial run on a old repository will download all files again, since no timestamp will be availble in the folder. (Similarly a refresh can be forced by deleting the timestamp in the aws folder)