### PR TITLE
Fixing multi syndrome in check

### DIFF
--- a/lib/model/case.py
+++ b/lib/model/case.py
@@ -260,35 +260,24 @@ class Case:
 
             for key, series in ps_dict.items():
                 contained = False
-                for kk, ss in ps_dict.items():
-                    if kk == key:
+                for other_key, other_series in ps_dict.items():
+                    if other_key == key:
                         continue
-                    if series <= set(ss):
+                    if series <= other_series:
                         contained = True
                 if not contained:
                     reduced_ps_dict[key] = series
 
-            # diagnosis_series = [
-            #     omim.omim_id_to_phenotypic_series(str(d)) or str(d)
-            #     for d in diagnosis["omim_id"]
-            # ]
-            # diagnosis_names = list(
-            #     set([d for d in diagnosis["syndrome_name"]])
-            # )
-
-            # if len(set(diagnosis_series)) > 1 \
-            #         and len(diagnosis_names) > 1:
             if len(reduced_ps_dict) > 1:
-                print(reduced_ps_dict.keys())
-                print(reduced_ps_dict)
                 issues.append(
                     {
                         "type": "MULTI_DIAGNOSIS",
                         "data": {
                             "orig": list(diagnosis["omim_id"]),
-                            # "series": diagnosis_series,
-                            # "names": diagnosis_names
-                            'dict': reduced_ps_dict
+                            'names': list(reduced_ps_dict.keys()),
+                            "converted_ids": [
+                                e for v in reduced_ps_dict.values() for e in v
+                            ]
                         }
                     }
                 )

--- a/lib/model/case.py
+++ b/lib/model/case.py
@@ -204,7 +204,7 @@ class Case:
         '''
         valid = True
         issues = []
-        
+
         # check if there is at least one feature (HPO)
         features = self.features
         if len(features) < 1:
@@ -214,9 +214,9 @@ class Case:
                 }
             )
             valid = False
-            
+
         scores = [
-            "gestalt_score", "feature_score", "pheno_score", "boqa_score"
+            "gestalt_score"
         ]
         max_scores = {s: max(self.syndromes[s]) for s in scores}
         zero_scores = [s for s, n in max_scores.items() if n <= 0]
@@ -263,7 +263,7 @@ class Case:
 
         if not self.get_variants():
             raw_entries = self.data.get_genomic_entries()
-            if not len(raw_entries):
+            if not raw_entries:
                 issues.append(
                     {
                         "type": "NO_GENOMIC",

--- a/lib/model/json_parser.py
+++ b/lib/model/json_parser.py
@@ -265,10 +265,10 @@ class JsonFile:
             directive: Define fields, on which loading operations should be
             done
         '''
-        self._js = self._linked(self._js, directive, self._corrected_keys)
+        self._js = self._linked(self._js, directive)
 
     @classmethod
-    def _linked(cls, data, load_directive, hidden_keys):
+    def _linked(cls, data, load_directive):
         '''Load data according to the provided load directive. This will
         recursively traverse the json structure and match it against the
         provided loading directive.
@@ -277,15 +277,13 @@ class JsonFile:
             for k, entry in load_directive.items():
                 if k not in data:
                     raise IndexError("{} not in data dict.".format(k))
-                elif k in hidden_keys:
-                    continue
                 # do not propagate hidden keys to deeper levels
-                data[k] = cls._linked(data[k], entry, [])
+                data[k] = cls._linked(data[k], entry)
         elif isinstance(load_directive, list):
             data = [
                 r for r in
                 [
-                    cls._linked(v, d, [])  # hidden keys not used further
+                    cls._linked(v, d)  # hidden keys not used further
                     for d in load_directive
                     for v in data
                 ]

--- a/lib/model/json_parser.py
+++ b/lib/model/json_parser.py
@@ -483,8 +483,17 @@ class NewJson(JsonFile):
         column marking the specific entry.
         '''
         # create a dataframe from the list of detected syndromes
-        syndromes_df = pandas.DataFrame.from_dict(
-            self._js['detected_syndromes'])
+        if self._js["detected_syndromes"]:
+            syndromes_df = pandas.DataFrame.from_dict(
+                self._js['detected_syndromes']
+            )
+        else:
+            syndromes_df = pandas.DataFrame(
+                columns=[
+                    "omim_id", "gestalt_score", "combined_score",
+                    "feature_score", "has_mask", "syndrome_name"
+                ]
+            )
 
         # force omim_id to always be a list, required for exploding the df
         syndromes_df['omim_id'] = syndromes_df['omim_id'].apply(

--- a/tests/test_case.py
+++ b/tests/test_case.py
@@ -44,13 +44,21 @@ class CaseTest(BaseMapping):
             (
                 "syndrome_with_card.json", True,
                 "Syndrome with available card did not pass."
-            )
+            ),
+            (
+                "no_scores_0.json", False,
+                "No transmitted detected syndromes"
+            ),
+            (
+                "no_scores_1.json", True,
+                "Missing scores because of transfer issues."
+            ),
         ]
         for fname, valid, msg in tests:
             with self.subTest(i=fname):
                 tcase = self.load_case(fname)
                 check_status, issues = tcase.check(self.omim)
-                if not check_status:
+                if check_status != valid:
                     print(issues)
                 self.assertEqual(check_status, valid, msg)
 
@@ -79,6 +87,50 @@ class CaseTest(BaseMapping):
             ("multi_diagnosis_19.json", True),
         ]
 
+        for test, result in tests:
+            with self.subTest(i=test):
+                tcase = self.load_case(test)
+                check_stats, issues = tcase.check(self.omim)
+                if not check_stats:
+                    print(issues)
+                self.assertEqual(check_stats, result)
+
+    def test_still_multi(self):
+        '''Test cases that are still classified as multi diagnosis.'''
+        tests = [
+            ("still_multi_0.json", True),
+            ("still_multi_1.json", True),
+            ("still_multi_2.json", True),
+            ("still_multi_3.json", True),
+            ("still_multi_4.json", True),
+            ("still_multi_5.json", True),
+            ("still_multi_6.json", True),
+            ("still_multi_7.json", True),
+            ("still_multi_8.json", True),
+            ("still_multi_9.json", True),
+            ("still_multi_10.json", True),
+            ("still_multi_11.json", True),
+            ("still_multi_12.json", True),
+            ("still_multi_13.json", True),
+            ("still_multi_14.json", True),
+            ("still_multi_15.json", True),
+            ("still_multi_16.json", True),
+            ("still_multi_17.json", True),
+        ]
+        for test, result in tests:
+            with self.subTest(i=test):
+                tcase = self.load_case(test)
+                check_stats, issues = tcase.check(self.omim)
+                if not check_stats:
+                    print(issues)
+                self.assertEqual(check_stats, result)
+
+    def test_hpo_no_score(self):
+        '''Test cases with hpo features but no scores.'''
+        tests = [
+            ("no_pheno_0.json", True),
+            ("no_pheno_1.json", True),
+        ]
         for test, result in tests:
             with self.subTest(i=test):
                 tcase = self.load_case(test)

--- a/tests/test_case.py
+++ b/tests/test_case.py
@@ -3,15 +3,21 @@ Test case functions
 '''
 import os
 import unittest
-from lib.model import json, case
+from lib.api import phenomizer
+from lib.model import json_parser, case
 from tests.test_json_loading import BaseMapping
 
 
 class CaseTest(BaseMapping):
     '''Case method tests.'''
 
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.phenomizer = phenomizer.PhenomizerService(config=cls.config)
+
     def load_json(self, name: str) -> dict:
-        loaded = json.NewJson.from_file(
+        loaded = json_parser.NewJson.from_file(
             self.get_case_path(name)
         )
         return loaded
@@ -22,6 +28,7 @@ class CaseTest(BaseMapping):
             error_fixer=self.error_fixer,
             omim_obj=self.omim,
         )
+        case_obj.phenomize(self.phenomizer)
         return case_obj
 
     def test_check(self):
@@ -42,5 +49,40 @@ class CaseTest(BaseMapping):
         for fname, valid, msg in tests:
             with self.subTest(i=fname):
                 tcase = self.load_case(fname)
-                check_status, _ = tcase.check(self.omim)
+                check_status, issues = tcase.check(self.omim)
+                if not check_status:
+                    print(issues)
                 self.assertEqual(check_status, valid, msg)
+
+    def test_multi_diagnosis(self):
+        '''Assert that cases with multiple diagnoses are correctly sorted.'''
+        tests = [
+            ("multi_diagnosis_0.json", True),
+            ("multi_diagnosis_1.json", True),
+            ("multi_diagnosis_2.json", True),
+            ("multi_diagnosis_3.json", True),
+            ("multi_diagnosis_4.json", True),
+            ("multi_diagnosis_5.json", True),
+            ("multi_diagnosis_6.json", True),
+            ("multi_diagnosis_7.json", True),
+            ("multi_diagnosis_8.json", True),
+            ("multi_diagnosis_9.json", True),
+            ("multi_diagnosis_10.json", True),
+            ("multi_diagnosis_11.json", True),
+            ("multi_diagnosis_12.json", True),
+            ("multi_diagnosis_13.json", True),
+            ("multi_diagnosis_14.json", True),
+            ("multi_diagnosis_15.json", True),
+            ("multi_diagnosis_16.json", True),
+            ("multi_diagnosis_17.json", True),
+            ("multi_diagnosis_18.json", True),
+            ("multi_diagnosis_19.json", True),
+        ]
+
+        for test, result in tests:
+            with self.subTest(i=test):
+                tcase = self.load_case(test)
+                check_stats, issues = tcase.check(self.omim)
+                if not check_stats:
+                    print(issues)
+                self.assertEqual(check_stats, result)

--- a/tests/test_face2gene.py
+++ b/tests/test_face2gene.py
@@ -13,8 +13,8 @@ class Face2GeneTest(BaseConfig):
 
     def test_search_syndrome_name(self):
         tests = [
-            ("Coffin-Siris", None),
-            ("Coffin-Siris Syndrome 3", None)
+            ("Multiple Congenital Anomalies-Hypotonia-Seizures Syndrome 1; MCAHS1", None),
+            ("Multiple Congenital Anomalies-Hypotonia-Seizures Syndrome", None)
         ]
         for test, correct in tests:
             with self.subTest(i=test):

--- a/tests/test_json_loading.py
+++ b/tests/test_json_loading.py
@@ -4,7 +4,7 @@ Test loading of jsons from new-style json files.
 import os
 import unittest
 from lib import errorfixer
-from lib.model import json, config
+from lib.model import json_parser, config
 from lib.api import mutalyzer, omim, phenomizer, face2gene
 
 from tests.test_config import BaseConfig
@@ -42,8 +42,8 @@ class JsonLoadingTest(BaseMapping):
     def setUp(self):
         input_file = os.path.join(self.input_path, "cases", "normal.json")
         error_file = os.path.join(self.input_path, "cases", "error_hgvs.json")
-        self.loaded_correct = json.NewJson.from_file(input_file)
-        self.loaded_error = json.NewJson.from_file(error_file)
+        self.loaded_correct = json_parser.Newjson_parser.from_file(input_file)
+        self.loaded_error = json_parser.Newjson_parser.from_file(error_file)
 
     def test_check(self):
         '''Test whether the file check is passing.'''


### PR DESCRIPTION
Multi syndrome check now tries to reduce number of syndromes by using set comparisons on generated phenotypic series. This should lead to phenotypic series subtypes (containing omim ids from another syndrome) to be merged into the syndrome with a larger or equal amount of ids.

I am still testing to run the entire pipeline. But no config changes should be necessary for these changes.

In check only gestalt score is now being used for comparisons. Pheno, boqa have been removed because of false negatives.

Running the tests requires a populated `tests/data` directory. Refer to Trello for data.
