### PR TITLE
Always keep reference transcript in hgvs string formatting

### DIFF
--- a/lib/model/hgvs_parser.py
+++ b/lib/model/hgvs_parser.py
@@ -10,6 +10,7 @@ import hgvs.parser
 import hgvs.validator
 import hgvs.exceptions
 import hgvs.assemblymapper
+import hgvs.config
 
 
 from lib.errorfixer import ErrorFixer
@@ -18,6 +19,10 @@ from lib.constants import HGVS_OPS, HGVS_PREFIX
 
 
 LOGGER = logging.getLogger("lib")
+
+
+# always leave the reference string in hgvs strings
+hgvs.config.global_config.formatting.max_ref_length = None
 
 
 # external API for hgvs string checking and RS number resolution
@@ -63,10 +68,10 @@ def clean_hgvs(hgvs_string: str) -> str:
     # remove any whitespace first
 
     no_white = "".join(hgvs_string.split())
-    #resolve strings with deldel
+    # resolve strings with deldel
     if "deldel" in hgvs_string:
         fixed_code = hgvs_string.replace("deldel", "del")
-        #exchange wrong "<" for ">"
+        # exchange wrong "<" for ">"
         fixed_code = fixed_code.replace('<', '>')
         return fixed_code
     # resolve strings of format NORMAL(PROTEIN):NORMAL(PROTEIN)
@@ -98,7 +103,7 @@ class HGVSModel:
     def __init__(
             self,
             entry_dict: dict,
-            error_fixer: Union[ErrorFixer, None]
+            error_fixer: ErrorFixer
     ):
         '''New gene entry format contains:
         entry_id - entry id of gene entry json file

--- a/lib/model/hgvs_parser.py
+++ b/lib/model/hgvs_parser.py
@@ -335,9 +335,9 @@ class HGVSModel:
                 transcript=transcript,
                 prefix=prefix,
                 position=position,
-                orig=orig,
+                orig=orig.upper(),
                 operation=operation,
-                sub=sub)
+                sub=sub.upper())
         hgvs_string = "".join(hgvs_string.split())
         return hgvs_string
 

--- a/tests/test_hgvs_parser.py
+++ b/tests/test_hgvs_parser.py
@@ -1,0 +1,47 @@
+import os
+import json
+import unittest
+
+from lib.model.hgvs_parser import HGVSModel
+
+from tests.test_json_loading import BaseMapping
+
+
+class HGVSTest(BaseMapping):
+
+    def load_genomic_entry(self, entry_name):
+        entry_path = os.path.join(
+            self.input_path, "genomics_entries", entry_name
+        )
+
+        with open(entry_path, "r") as gfile:
+            data = json.load(gfile)
+        return data
+
+    def create_model(self, data):
+        return HGVSModel(data, error_fixer=self.error_fixer)
+
+    def test_normal_entries(self):
+        tests = [
+        ]
+
+        for test in tests:
+            test_data = self.load_genomic_entry(test)
+            model = self.create_model(test_data)
+            print(model.variants)
+
+
+    def test_huge_hgvs(self):
+        tests = [
+            (
+                "huge_hgvs.json",
+                ["NM_003220.2:c.826_842delCTGCCTGCAGGGAGACGinsAGGAT"]
+            )
+        ]
+
+        for test, correct in tests:
+            test_data = self.load_genomic_entry(test)
+            model = self.create_model(test_data)
+            var_strs = [str(v) for v in model.variants]
+            print(var_strs)
+            self.assertListEqual(var_strs, correct)

--- a/tests/test_hgvs_parser.py
+++ b/tests/test_hgvs_parser.py
@@ -23,12 +23,18 @@ class HGVSTest(BaseMapping):
 
     def test_normal_entries(self):
         tests = [
+            (
+                "deleted_base.json",
+                ['NM_000489.4:c.7205delT']
+            )
+
         ]
 
-        for test in tests:
+        for test, correct in tests:
             test_data = self.load_genomic_entry(test)
             model = self.create_model(test_data)
-            print(model.variants)
+            var_strs = [str(v) for v in model.variants]
+            self.assertListEqual(var_strs, correct)
 
 
     def test_huge_hgvs(self):
@@ -43,5 +49,4 @@ class HGVSTest(BaseMapping):
             test_data = self.load_genomic_entry(test)
             model = self.create_model(test_data)
             var_strs = [str(v) for v in model.variants]
-            print(var_strs)
             self.assertListEqual(var_strs, correct)


### PR DESCRIPTION
See [Trello](https://trello.com/c/5wqNXuCx/60-case-240762) for specific information.

This should fix issues with failures of Jannovar to parse delins with missing reference transcripts.